### PR TITLE
ci: run verification only on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches: [main, dev]
   pull_request:
     branches: [main, dev]
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,6 +13,7 @@ env:
 jobs:
   deploy:
     runs-on: kkldream-jigsaw-puzzle-solver
+    environment: 'main'
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary
- remove `push` trigger from `CI`
- keep `deploy.yml` on `push main/dev`

## Resulting behavior
- open/update PR to `main` or `dev`: run `CI`
- merge/push to `main` or `dev`: only run `Deploy to K8s`
