### PR TITLE
docs: 重寫 Jigsaw Puzzle Solver 頁面文案與文件

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,110 @@
+# AGENTS.md
+
+本文件提供在 Jigsaw Puzzle Solver repository 內協作時的實務指引。目標是讓貢獻者在不破壞既有流程的前提下，快速理解專案、找到正確檔案、使用一致的語言與修改邊界。
+
+## 專案概觀
+
+Jigsaw Puzzle Solver 是一個拼圖定位輔助工具。使用者會先建立專案並上傳完整拼圖影像，再於專案頁上傳局部拼圖片段照片。系統會呼叫 Python 影像比對 solver，回傳特徵分布、特徵匹配等結果圖，幫助使用者判斷該片拼圖應放置的位置。
+
+## 技術堆疊
+
+- 前端與 API：Next.js 14、React 18、App Router、Tailwind CSS
+- 狀態管理：Zustand
+- 資料庫：MongoDB + Mongoose
+- 物件儲存：AWS S3
+- 影像求解：Python、OpenCV / SIFT
+- 打包與執行：PyInstaller、Docker
+- CI / CD：GitHub Actions
+- 部署：Kubernetes base + `main` / `dev` overlays
+
+## 重要目錄與檔案
+
+- `README.md`：給使用者與開發者的專案總覽。
+- `AGENTS.md`：本文件，提供協作與修改指引。
+- `Dockerfile`：正式建置流程，包含 Python solver 與 Next.js 應用。
+- `.github/workflows/`：CI 與部署 workflow。
+- `k8s/base/`：共用 Kubernetes 資源定義。
+- `k8s/overlays/dev/`：開發環境覆蓋設定。
+- `k8s/overlays/main/`：正式環境覆蓋設定。
+- `python/solver.py`：拼圖比對核心邏輯。
+- `python/executable.py`：solver 打包入口。
+- `web/src/app/page.tsx`：首頁。
+- `web/src/app/project/page.tsx`：專案列表頁。
+- `web/src/app/project/[projectId]/page.tsx`：專案詳情與求解入口。
+- `web/src/app/api/project/route.ts`：專案列表 / 建立。
+- `web/src/app/api/solve/route.ts`：局部拼圖片段求解。
+- `web/src/service/solverService.ts`：Next.js 呼叫 Python 執行檔的橋接。
+
+## 本機開發、測試、建置
+
+### Python solver
+
+```bash
+cd python
+pip install -r requirements.txt
+pip install pyinstaller
+pyinstaller --distpath ../web/dist --onefile executable.py
+```
+
+### Web app
+
+```bash
+cd web
+corepack enable
+corepack prepare yarn@1.22.22 --activate
+yarn install
+yarn dev
+```
+
+### 驗證與建置
+
+```bash
+cd web
+yarn lint
+yarn build
+yarn start
+```
+
+## 貢獻規則
+
+- 優先做小範圍、可驗證的修改，不要把內容調整擴大成架構重寫。
+- 若修改 UI 文案，請同步檢查首頁、Projects、About、modal 與可見提示是否仍然一致。
+- 若修改 API、solver 介面或資料結構，必須確認前端型別、API route、S3 / MongoDB 流程是否仍相容。
+- 不要隨意改動 `Dockerfile`、`.github/workflows/`、`k8s/`。這些檔案會直接影響 CI/CD 與部署行為。
+- 專案可能存在使用者尚未提交的變更。除非明確要求，請不要回滾與當前任務無關的修改。
+
+## 文案與語言指引
+
+- Repository 文件以繁體中文為主，面向開發者與貢獻者。
+- 網站導覽與主要公共頁面目前以英文為主，例如 `Home`、`Projects`、`About`、`New Project`。
+- App 內既有的工作流標籤與操作提示可保留繁體中文，例如：
+  - `建立新的專案`
+  - `參考完整拼圖`
+  - `上傳部分拼圖`
+- 避免使用泛用佔位詞，例如 `Your Company`、`Julo...`、`Upload a picture`。
+- 文案應明確描述三件事：
+  - 完整拼圖影像是什麼
+  - 局部拼圖片段照片是什麼
+  - 系統會產出哪些比對結果
+
+## 部署與環境注意事項
+
+- `web/src/service/solverService.ts` 在不同平台使用不同執行檔路徑；內容改動時不要破壞既有路徑假設。
+- `.env` 相關設定至少涉及 MongoDB 與 AWS S3。文件可以改善，但不要擅自更改變數命名與讀取邏輯。
+- GitHub Actions 會對 `main`、`dev` 分支執行不同部署上下文；請避免未經確認就改動 branch、image tag、secret 名稱或 Kustomize 路徑。
+- K8s overlays 已區分 `main` 與 `dev`，若只是內容或文件修改，不應連帶更動 deployment / service patch。
+
+## 適合優先改善的範圍
+
+- README、AGENTS、About page、首頁與 Projects 頁面的說明文字。
+- 顯而易見的 placeholder 文案、`sr-only` 品牌名稱、上傳提示文字。
+- 不改邏輯的可讀性改善，例如更清楚的段落、標題、說明卡片。
+
+## 不要輕易變更的範圍
+
+- Python solver 演算法與輸出格式。
+- API route 的 request / response 契約。
+- MongoDB schema 欄位名稱。
+- Docker multi-stage build 流程。
+- GitHub Actions 部署邏輯。
+- Kubernetes `base` 與 `overlays` 的部署設定。

--- a/README.md
+++ b/README.md
@@ -1,24 +1,129 @@
 # Jigsaw Puzzle Solver
 
-說明待補...
+Jigsaw Puzzle Solver 是一個協助使用者「找出拼圖片段屬於完整拼圖哪個位置」的 Web 應用程式。使用者先建立專案並上傳完整拼圖影像，之後可在專案頁面上傳局部拼圖片段照片，系統會透過影像特徵比對流程產出結果圖，例如特徵分布與特徵配對結果，協助判斷該片拼圖應放置的位置。
 
-## 開發環境建置
+## 主要功能
 
-1. 安裝 Python 開發環境
-    ```bash
-    pip install opencv-python numpy matplotlib pyinstaller
-    ```
-2. 使用 PyInstaller 生成執行檔
-    ```bash
-    cd python
-    pyinstaller --distpath ../web/dist --onefile executable.py
-    ```
-3. 安裝 Next.js 開發環境
-    ```bash
-    cd ../web
-    yarn
-    ```
-4. 啟動 Next.js 開發伺服器
-    ```bash
-    yarn dev
-    ```
+- 建立拼圖專案並保存完整拼圖影像。
+- 首頁顯示近期專案，方便快速回到最近處理的拼圖。
+- Projects 頁面列出所有專案，已登入使用者可建立新專案。
+- 專案詳情頁可上傳局部拼圖片段照片並執行查找。
+- 顯示求解結果影像，例如 feature distribution、feature matching 等分析圖。
+- 以 MongoDB 保存專案資料，以 AWS S3 保存影像檔案。
+
+## 架構概觀
+
+- `web/`：Next.js 14 前端與 API routes。
+- `python/`：以 OpenCV/SIFT 為核心的拼圖求解程式，最終會被打包成可執行檔。
+- `MongoDB`：保存專案名稱、影像資訊與基本中繼資料。
+- `AWS S3`：保存完整拼圖影像與相關影像資產。
+- `Dockerfile`：多階段建置，先打包 Python solver，再建置 Next.js 應用。
+- `GitHub Actions`：執行 lint、Docker build，以及 `main` / `dev` 分支的部署流程。
+- `k8s/overlays/main`、`k8s/overlays/dev`：分別對應正式與開發環境的 Kubernetes 覆蓋設定。
+
+## Repo 結構
+
+```text
+.
+├── README.md
+├── AGENTS.md
+├── Dockerfile
+├── .github/workflows/     # CI 與部署流程
+├── k8s/                   # base 與 main/dev overlays
+├── python/                # OpenCV / SIFT solver 與執行檔入口
+└── web/                   # Next.js App Router、API routes、前端元件
+```
+
+其中幾個常用位置如下：
+
+- `web/src/app/page.tsx`：首頁。
+- `web/src/app/project/page.tsx`：專案列表頁。
+- `web/src/app/project/[projectId]/page.tsx`：專案詳情與拼圖查找流程。
+- `web/src/app/api/project/route.ts`：專案建立與列表 API。
+- `web/src/app/api/solve/route.ts`：呼叫 solver 的 API。
+- `web/src/service/solverService.ts`：Next.js 端呼叫 Python 可執行檔的橋接層。
+- `python/executable.py`：PyInstaller 打包入口。
+- `python/solver.py`：影像比對核心邏輯。
+
+## 本機開發
+
+### 1. 安裝 Python 依賴
+
+```bash
+cd python
+pip install -r requirements.txt
+pip install pyinstaller
+```
+
+### 2. 產生 solver 可執行檔
+
+```bash
+cd python
+pyinstaller --distpath ../web/dist --onefile executable.py
+```
+
+### 3. 設定 Web 環境變數
+
+以 `web/.env.example` 為基礎建立 `.env.local`，至少需要：
+
+```env
+MONGODB_URL=mongodb://<username>:<password>@<host>:<port>
+AWS_ACCESS_KEY_ID=...
+AWS_SECRET_ACCESS_KEY=...
+AWS_REGION=ap-northeast-1
+```
+
+### 4. 安裝前端依賴並啟動開發伺服器
+
+```bash
+cd web
+corepack enable
+corepack prepare yarn@1.22.22 --activate
+yarn install
+yarn dev
+```
+
+預設會啟動在 `http://localhost:3000`。
+
+## 常用指令
+
+```bash
+cd web
+yarn dev
+yarn lint
+yarn build
+yarn start
+```
+
+若要重新產生 solver，可回到 `python/` 再執行一次 PyInstaller 打包。
+
+## 部署概觀
+
+- 根目錄 `Dockerfile` 會先在 Python 階段打包 solver，再在 Node.js 階段安裝前端依賴與建置 Next.js。
+- GitHub Actions 的 CI 會在 Pull Request 上執行 `yarn lint` 與 Docker build。
+- `main` 與 `dev` 分支推送後會觸發部署 workflow：
+  - 建立並推送 Docker image。
+  - 以 GitHub Secrets 建立或更新 Kubernetes Secret。
+  - 套用 `k8s/overlays/main` 或 `k8s/overlays/dev`。
+  - 等待 deployment rollout 完成。
+
+若只是調整內容、文案或 UI，請避免順手變更 Dockerfile、workflow 與 K8s overlay，除非你已確認部署需求真的改變。
+
+## 疑難排解
+
+- `Process exited with code ...`
+  - 通常表示 Python solver 可執行檔不存在、打包失敗，或執行環境缺少必要系統函式庫。先重新產生 `web/dist/executable`，再確認 Docker / 主機安裝了 OpenCV 所需依賴。
+- `MONGODB_URI is not set`
+  - 專案實作實際讀取的是 `MONGODB_URL`。請確認 `.env.local` 已設定且有被 Next.js 載入。
+- 上傳成功但查找失敗
+  - 先確認 S3 憑證可用、完整拼圖影像可被存取，並檢查 solver 輸出是否能正確解析為 JSON。
+- 本機看不到求解結果圖
+  - 檢查是否已登入、是否成功上傳局部拼圖片段，以及瀏覽器 console / Next.js server log 是否有 API 錯誤訊息。
+
+## 補充
+
+本專案同時涵蓋前端、影像處理、容器化與 K8s 部署設定。若你要調整文件或介面文案，請優先維持：
+
+- 使用者對「完整拼圖 / 局部拼圖片段 / 比對結果」的理解一致。
+- 英文導覽與按鈕文案的一致性。
+- 已存在的繁體中文工作流標籤與操作提示。

--- a/web/src/app/_components/ui/Header.tsx
+++ b/web/src/app/_components/ui/Header.tsx
@@ -37,7 +37,7 @@ export default function Header() {
                 <nav className="flex items-center justify-between p-6 lg:px-8" aria-label="Global">
                     <div className="flex lg:flex-1">
                         <Link href="/" className="-m-1.5 p-1.5">
-                            <span className="sr-only">Your Company</span>
+                            <span className="sr-only">Jigsaw Puzzle Solver</span>
                             <NextImg
                                 className="h-8 w-auto"
                                 src={favicon}
@@ -83,7 +83,7 @@ export default function Header() {
                         className="fixed inset-y-0 right-0 z-50 w-full overflow-y-auto bg-white px-6 py-6 sm:max-w-sm sm:ring-1 sm:ring-gray-900/10">
                         <div className="flex items-center justify-between">
                             <a href="/" className="-m-1.5 p-1.5">
-                                <span className="sr-only">Your Company</span>
+                                <span className="sr-only">Jigsaw Puzzle Solver</span>
                                 <NextImg
                                     className="h-8 w-auto"
                                     src={favicon}

--- a/web/src/app/about/page.tsx
+++ b/web/src/app/about/page.tsx
@@ -3,81 +3,68 @@ export default function Page() {
         <div className="px-6 py-24 sm:py-32 lg:px-8">
             <div className="mx-auto max-w-5xl">
                 <div className="mx-auto max-w-3xl text-center">
-                    <p className="text-base font-semibold leading-7 text-indigo-600">About the project</p>
+                    <p className="text-base font-semibold leading-7 text-indigo-600">關於這個專案</p>
                     <h2 className="mt-2 text-4xl font-bold tracking-tight text-gray-900 sm:text-6xl">
-                        About Jigsaw Puzzle Solver
+                        關於 Jigsaw Puzzle Solver
                     </h2>
                     <p className="mt-6 text-lg leading-8 text-gray-600">
-                        Jigsaw Puzzle Solver is a puzzle-assistance web app built for the moment when you have one
-                        loose piece in hand and need help figuring out where it belongs. Instead of scanning the entire
-                        puzzle by eye, you upload a photo of the partial piece and compare it against a saved image of
-                        the complete puzzle.
+                        Jigsaw Puzzle Solver 是一個協助拼圖定位的網站工具。當你手上有一片不知道該放哪裡的拼圖時，
+                        不需要只靠肉眼反覆比對整張拼圖；你可以先保存完整拼圖影像，再上傳局部拼圖片段照片，讓系統協助你縮小可能位置。
                     </p>
                 </div>
 
                 <div className="mx-auto mt-16 grid max-w-5xl grid-cols-1 gap-6 lg:grid-cols-3">
                     <div className="rounded-2xl bg-white p-8 shadow-sm ring-1 ring-gray-200">
-                        <h3 className="text-lg font-semibold text-gray-900">What it does</h3>
+                        <h3 className="text-lg font-semibold text-gray-900">它能做什麼</h3>
                         <p className="mt-4 text-sm leading-6 text-gray-600">
-                            Each project begins with a reference image of the full puzzle. Once that image is saved,
-                            you can upload a partial-piece photo and let the app generate visual matching outputs that
-                            help narrow down the piece location.
+                            每個專案都會先建立一張完整拼圖的參考圖。完成後，你可以上傳局部拼圖片段照片，系統會產出視覺化的比對結果圖，幫助你更快找出這片拼圖可能的位置。
                         </p>
                     </div>
                     <div className="rounded-2xl bg-white p-8 shadow-sm ring-1 ring-gray-200">
-                        <h3 className="text-lg font-semibold text-gray-900">Who it is for</h3>
+                        <h3 className="text-lg font-semibold text-gray-900">適合誰使用</h3>
                         <p className="mt-4 text-sm leading-6 text-gray-600">
-                            The app is useful for puzzle hobbyists, families working on large puzzles together, and
-                            anyone who wants a repeatable workflow for checking difficult pieces without losing track of
-                            progress.
+                            它適合喜歡拼圖的人、一起挑戰大拼圖的家庭，也適合想把比對流程整理得更清楚、不想每次都從頭重新找位置的使用者。
                         </p>
                     </div>
                     <div className="rounded-2xl bg-white p-8 shadow-sm ring-1 ring-gray-200">
-                        <h3 className="text-lg font-semibold text-gray-900">Why it is practical</h3>
+                        <h3 className="text-lg font-semibold text-gray-900">為什麼實用</h3>
                         <p className="mt-4 text-sm leading-6 text-gray-600">
-                            Instead of relying on memory alone, the project keeps your reference image, project list,
-                            and result images together so you can return to the same puzzle later and continue from the
-                            browser.
+                            除了完整拼圖參考圖，專案也會把你的專案列表與比對結果圖整理在一起，之後回到同一個拼圖時，可以直接從瀏覽器接續查看，不必只靠記憶重找。
                         </p>
                     </div>
                 </div>
 
                 <div className="mx-auto mt-16 grid max-w-5xl grid-cols-1 gap-8 lg:grid-cols-2">
                     <section className="rounded-2xl bg-gray-50 p-8 ring-1 ring-gray-200">
-                        <h3 className="text-xl font-semibold text-gray-900">How the workflow works</h3>
+                        <h3 className="text-xl font-semibold text-gray-900">使用流程</h3>
                         <ol className="mt-6 space-y-4 text-sm leading-6 text-gray-600">
-                            <li>1. Create a project and upload the complete puzzle image.</li>
-                            <li>2. Open the project when you want to inspect a specific puzzle piece.</li>
-                            <li>3. Upload a photo of the partial puzzle piece or local puzzle area.</li>
-                            <li>4. Review the generated result images, including feature distribution and matching.</li>
-                            <li>5. Use those visual cues to decide where the piece most likely belongs.</li>
+                            <li>1. 建立專案，先上傳完整拼圖影像作為參考。</li>
+                            <li>2. 需要確認某片拼圖位置時，開啟對應的專案。</li>
+                            <li>3. 上傳該片局部拼圖片段照片，或拍攝局部區域影像。</li>
+                            <li>4. 查看系統產生的結果圖，例如特徵分布與特徵匹配結果。</li>
+                            <li>5. 根據這些視覺化比對資訊，判斷拼圖最可能放置的位置。</li>
                         </ol>
                     </section>
 
                     <section className="rounded-2xl bg-gray-50 p-8 ring-1 ring-gray-200">
-                        <h3 className="text-xl font-semibold text-gray-900">Technical approach</h3>
+                        <h3 className="text-xl font-semibold text-gray-900">技術做法</h3>
                         <ul className="mt-6 space-y-4 text-sm leading-6 text-gray-600">
-                            <li>Next.js powers the web interface and API routes.</li>
-                            <li>MongoDB stores project records and image metadata.</li>
-                            <li>AWS S3 stores uploaded puzzle images.</li>
-                            <li>Python with OpenCV and SIFT performs the image feature analysis.</li>
-                            <li>Docker, GitHub Actions, and Kubernetes support build and deployment workflows.</li>
+                            <li>網站介面與 API 由 Next.js 提供。</li>
+                            <li>MongoDB 用來保存專案資料與影像相關資訊。</li>
+                            <li>AWS S3 負責儲存上傳的拼圖圖片。</li>
+                            <li>Python 搭配 OpenCV 與 SIFT 進行影像特徵分析。</li>
+                            <li>Docker、GitHub Actions 與 Kubernetes 支援建置與部署流程。</li>
                         </ul>
                     </section>
                 </div>
 
                 <div className="mx-auto mt-16 max-w-4xl rounded-2xl bg-white p-8 shadow-sm ring-1 ring-gray-200">
-                    <h3 className="text-xl font-semibold text-gray-900">What you can expect from the results</h3>
+                    <h3 className="text-xl font-semibold text-gray-900">你會看到哪些結果</h3>
                     <p className="mt-4 text-sm leading-6 text-gray-600">
-                        The solver does not simply return a single text answer. It produces result images that make the
-                        matching process easier to inspect, including views that show how image features are distributed
-                        and how the uploaded piece aligns with the reference puzzle. That makes the app useful both as a
-                        practical helper and as a transparent visual aid when the match is not obvious at first glance.
+                        Solver 不會只回傳一句簡單的文字答案，而是提供可以實際檢視的結果圖，讓你看到影像特徵如何分布、上傳的拼圖片段和完整拼圖之間如何匹配。遇到不容易一眼判斷的位置時，這些圖會比單純描述更有幫助。
                     </p>
                     <p className="mt-4 text-sm leading-6 text-gray-600">
-                        In short, Jigsaw Puzzle Solver is designed to turn a frustrating manual search task into a
-                        structured, repeatable workflow that combines image processing with a lightweight project
-                        management interface.
+                        整體來說，Jigsaw Puzzle Solver 想做的是把原本容易卡住的人工找片流程，整理成一套清楚、可重複使用的操作方式，讓影像比對與專案管理可以在同一個介面中完成。
                     </p>
                 </div>
             </div>

--- a/web/src/app/about/page.tsx
+++ b/web/src/app/about/page.tsx
@@ -1,12 +1,85 @@
 export default function Page() {
     return (
         <div className="px-6 py-24 sm:py-32 lg:px-8">
-            <div className="mx-auto max-w-2xl text-center">
-                <p className="text-base font-semibold leading-7 text-indigo-600">Julo Julo Julo Julo Julo.</p>
-                <h2 className="mt-2 text-4xl font-bold tracking-tight text-gray-900 sm:text-6xl">About Julo</h2>
-                <p className="mt-6 text-lg leading-8 text-gray-600">
-                    Julo Julo Julo Julo Julo Julo Julo Julo Julo Julo Julo Julo Julo Julo Julo Julo.
-                </p>
+            <div className="mx-auto max-w-5xl">
+                <div className="mx-auto max-w-3xl text-center">
+                    <p className="text-base font-semibold leading-7 text-indigo-600">About the project</p>
+                    <h2 className="mt-2 text-4xl font-bold tracking-tight text-gray-900 sm:text-6xl">
+                        About Jigsaw Puzzle Solver
+                    </h2>
+                    <p className="mt-6 text-lg leading-8 text-gray-600">
+                        Jigsaw Puzzle Solver is a puzzle-assistance web app built for the moment when you have one
+                        loose piece in hand and need help figuring out where it belongs. Instead of scanning the entire
+                        puzzle by eye, you upload a photo of the partial piece and compare it against a saved image of
+                        the complete puzzle.
+                    </p>
+                </div>
+
+                <div className="mx-auto mt-16 grid max-w-5xl grid-cols-1 gap-6 lg:grid-cols-3">
+                    <div className="rounded-2xl bg-white p-8 shadow-sm ring-1 ring-gray-200">
+                        <h3 className="text-lg font-semibold text-gray-900">What it does</h3>
+                        <p className="mt-4 text-sm leading-6 text-gray-600">
+                            Each project begins with a reference image of the full puzzle. Once that image is saved,
+                            you can upload a partial-piece photo and let the app generate visual matching outputs that
+                            help narrow down the piece location.
+                        </p>
+                    </div>
+                    <div className="rounded-2xl bg-white p-8 shadow-sm ring-1 ring-gray-200">
+                        <h3 className="text-lg font-semibold text-gray-900">Who it is for</h3>
+                        <p className="mt-4 text-sm leading-6 text-gray-600">
+                            The app is useful for puzzle hobbyists, families working on large puzzles together, and
+                            anyone who wants a repeatable workflow for checking difficult pieces without losing track of
+                            progress.
+                        </p>
+                    </div>
+                    <div className="rounded-2xl bg-white p-8 shadow-sm ring-1 ring-gray-200">
+                        <h3 className="text-lg font-semibold text-gray-900">Why it is practical</h3>
+                        <p className="mt-4 text-sm leading-6 text-gray-600">
+                            Instead of relying on memory alone, the project keeps your reference image, project list,
+                            and result images together so you can return to the same puzzle later and continue from the
+                            browser.
+                        </p>
+                    </div>
+                </div>
+
+                <div className="mx-auto mt-16 grid max-w-5xl grid-cols-1 gap-8 lg:grid-cols-2">
+                    <section className="rounded-2xl bg-gray-50 p-8 ring-1 ring-gray-200">
+                        <h3 className="text-xl font-semibold text-gray-900">How the workflow works</h3>
+                        <ol className="mt-6 space-y-4 text-sm leading-6 text-gray-600">
+                            <li>1. Create a project and upload the complete puzzle image.</li>
+                            <li>2. Open the project when you want to inspect a specific puzzle piece.</li>
+                            <li>3. Upload a photo of the partial puzzle piece or local puzzle area.</li>
+                            <li>4. Review the generated result images, including feature distribution and matching.</li>
+                            <li>5. Use those visual cues to decide where the piece most likely belongs.</li>
+                        </ol>
+                    </section>
+
+                    <section className="rounded-2xl bg-gray-50 p-8 ring-1 ring-gray-200">
+                        <h3 className="text-xl font-semibold text-gray-900">Technical approach</h3>
+                        <ul className="mt-6 space-y-4 text-sm leading-6 text-gray-600">
+                            <li>Next.js powers the web interface and API routes.</li>
+                            <li>MongoDB stores project records and image metadata.</li>
+                            <li>AWS S3 stores uploaded puzzle images.</li>
+                            <li>Python with OpenCV and SIFT performs the image feature analysis.</li>
+                            <li>Docker, GitHub Actions, and Kubernetes support build and deployment workflows.</li>
+                        </ul>
+                    </section>
+                </div>
+
+                <div className="mx-auto mt-16 max-w-4xl rounded-2xl bg-white p-8 shadow-sm ring-1 ring-gray-200">
+                    <h3 className="text-xl font-semibold text-gray-900">What you can expect from the results</h3>
+                    <p className="mt-4 text-sm leading-6 text-gray-600">
+                        The solver does not simply return a single text answer. It produces result images that make the
+                        matching process easier to inspect, including views that show how image features are distributed
+                        and how the uploaded piece aligns with the reference puzzle. That makes the app useful both as a
+                        practical helper and as a transparent visual aid when the match is not obvious at first glance.
+                    </p>
+                    <p className="mt-4 text-sm leading-6 text-gray-600">
+                        In short, Jigsaw Puzzle Solver is designed to turn a frustrating manual search task into a
+                        structured, repeatable workflow that combines image processing with a lightweight project
+                        management interface.
+                    </p>
+                </div>
             </div>
         </div>
     );

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -17,7 +17,7 @@ const geistMono = localFont({
 
 export const metadata: Metadata = {
     title: "Jigsaw Puzzle Solver",
-    description: "Jigsaw Puzzle Solver helps you match an uploaded puzzle-piece photo against the full puzzle image and review visual feature-matching results in the browser.",
+    description: "Jigsaw Puzzle Solver 讓你先上傳完整拼圖影像，再上傳局部拼圖片段照片，並在瀏覽器中查看特徵分布與特徵匹配等比對結果圖。",
 };
 
 export default function RootLayout({children}: Readonly<{ children: React.ReactNode }>) {

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -17,7 +17,7 @@ const geistMono = localFont({
 
 export const metadata: Metadata = {
     title: "Jigsaw Puzzle Solver",
-    description: "Julo Julo Julo Julo Julo Julo Julo Julo Julo Julo Julo Julo Julo Julo Julo Julo.",
+    description: "Jigsaw Puzzle Solver helps you match an uploaded puzzle-piece photo against the full puzzle image and review visual feature-matching results in the browser.",
 };
 
 export default function RootLayout({children}: Readonly<{ children: React.ReactNode }>) {

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -16,9 +16,8 @@ export default function Home() {
                         lver
                     </h1>
                     <p className="mt-6 text-lg leading-8 text-gray-600">
-                        Jigsaw Puzzle Solver helps you locate where a loose puzzle piece belongs by comparing a
-                        partial-piece photo with the full puzzle reference image. From this homepage, you can review
-                        recent projects and jump back into the puzzles you have been working on.
+                        Jigsaw Puzzle Solver 會先讓你上傳完整拼圖作為參考，再上傳手上的局部拼圖片段照片，
+                        系統會產出特徵分布與特徵匹配等比對結果圖，協助你判斷這片拼圖最可能的位置。你也可以從這裡快速查看最近的專案並繼續處理中的拼圖。
                     </p>
                 </div>
                 <div className="mt-16 flow-root sm:mt-24">
@@ -29,7 +28,7 @@ export default function Home() {
                 </div>
                 <div className="mt-10 flex items-center justify-center gap-x-6">
                     <a href="/project" className="text-sm font-semibold leading-6 text-gray-900">
-                        View More Projects <span aria-hidden="true">→</span>
+                        查看更多專案 <span aria-hidden="true">→</span>
                     </a>
                 </div>
             </div>

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -16,7 +16,9 @@ export default function Home() {
                         lver
                     </h1>
                     <p className="mt-6 text-lg leading-8 text-gray-600">
-                        Julo Julo Julo Julo Julo Julo Julo Julo Julo Julo Julo Julo Julo Julo Julo Julo.
+                        Jigsaw Puzzle Solver helps you locate where a loose puzzle piece belongs by comparing a
+                        partial-piece photo with the full puzzle reference image. From this homepage, you can review
+                        recent projects and jump back into the puzzles you have been working on.
                     </p>
                 </div>
                 <div className="mt-16 flow-root sm:mt-24">

--- a/web/src/app/project/[projectId]/_components/UploadGrid.tsx
+++ b/web/src/app/project/[projectId]/_components/UploadGrid.tsx
@@ -36,7 +36,9 @@ export default function UploadGrid(props: {
                             ) : (
                                 <div>
                                     <span
-                                        className="m-8 block text-sm font-semibold text-gray-900">Upload a picture</span>
+                                        className="m-8 block text-sm font-semibold text-gray-900">
+                                            Upload a partial puzzle photo
+                                        </span>
                                 </div>
                             )}
                         </label>

--- a/web/src/app/project/[projectId]/_components/UploadGrid.tsx
+++ b/web/src/app/project/[projectId]/_components/UploadGrid.tsx
@@ -37,7 +37,7 @@ export default function UploadGrid(props: {
                                 <div>
                                     <span
                                         className="m-8 block text-sm font-semibold text-gray-900">
-                                            Upload a partial puzzle photo
+                                            上傳局部拼圖片段照片
                                         </span>
                                 </div>
                             )}

--- a/web/src/app/project/page.tsx
+++ b/web/src/app/project/page.tsx
@@ -17,7 +17,9 @@ export default function Page() {
                             All Projects
                         </h1>
                         <p className="mt-6 text-lg leading-8 text-gray-600">
-                            Julo Julo Julo Julo Julo Julo Julo Julo Julo Julo Julo Julo Julo Julo Julo Julo.
+                            A project stores the full reference image for one puzzle so you can upload partial-piece
+                            photos and compare them later. Use New Project to create a fresh workspace by uploading the
+                            complete puzzle image first.
                         </p>
                         <div className="mt-10 flex items-center justify-center gap-x-6">
                             <button

--- a/web/src/app/project/page.tsx
+++ b/web/src/app/project/page.tsx
@@ -14,12 +14,10 @@ export default function Page() {
                 <div className="mx-auto max-w-7xl px-6 lg:px-8">
                     <div className="mx-auto max-w-2xl text-center">
                         <h1 className="text-3xl font-bold tracking-tight text-gray-900 sm:text-5xl">
-                            All Projects
+                            所有專案
                         </h1>
                         <p className="mt-6 text-lg leading-8 text-gray-600">
-                            A project stores the full reference image for one puzzle so you can upload partial-piece
-                            photos and compare them later. Use New Project to create a fresh workspace by uploading the
-                            complete puzzle image first.
+                            每個專案都會保存一組完整拼圖參考圖，方便你之後上傳局部拼圖片段照片進行比對。開始新專案時，請先上傳完整拼圖影像，之後就能持續查看系統回傳的比對結果圖。
                         </p>
                         <div className="mt-10 flex items-center justify-center gap-x-6">
                             <button


### PR DESCRIPTION
## 摘要
- 重寫首頁、Projects 與 About 頁面的說明文字，移除 Julo 等佔位內容
- 新增 AGENTS.md，整理協作指引、文案規範與重要目錄
- 重構 README.md，補上專案概述、架構、開發、部署與疑難排解
- 修正 metadata description、header 品牌 sr-only 文字與上傳區提示文案

## 驗證
- npm run lint ✅
- npm run build ⚠️ 在本機容器內因 Node 記憶體不足 OOM，中途失敗；此次變更僅為文案/文件，已確認 lint 通過，且 dev 分支 Deploy to K8s workflow 已成功完成

## 補充
- 本次依照需求使用 codex CLI 進行內容修改
- 變更已直接推送到 dev，請先至 dev 站查看內容是否符合預期