### PR TITLE
refactor: 統一 jigsaw solver base 資源配置

### DIFF
--- a/k8s/base/deployment.yaml
+++ b/k8s/base/deployment.yaml
@@ -32,11 +32,11 @@ spec:
                 name: jigsaw-puzzle-solver-secrets
           resources:
             requests:
-              memory: "128Mi"
+              memory: "256Mi"
               cpu: "100m"
             limits:
-              memory: "512Mi"
-              cpu: "500m"
+              memory: "2Gi"
+              cpu: "1000m"
           readinessProbe:
             httpGet:
               path: /

--- a/k8s/overlays/dev/deployment-patch.yaml
+++ b/k8s/overlays/dev/deployment-patch.yaml
@@ -19,10 +19,3 @@ spec:
           envFrom:
             - secretRef:
                 name: jigsaw-puzzle-solver-secrets-dev
-          resources:
-            requests:
-              memory: "256Mi"
-              cpu: "100m"
-            limits:
-              memory: "1Gi"
-              cpu: "500m"

--- a/k8s/overlays/main/deployment-patch.yaml
+++ b/k8s/overlays/main/deployment-patch.yaml
@@ -19,10 +19,3 @@ spec:
           envFrom:
             - secretRef:
                 name: jigsaw-puzzle-solver-secrets-main
-          resources:
-            requests:
-              memory: "256Mi"
-              cpu: "100m"
-            limits:
-              memory: "1Gi"
-              cpu: "500m"


### PR DESCRIPTION
## 摘要
- 將 jigsaw-puzzle-solver 的 resources 改回由 `k8s/base/deployment.yaml` 統一管理
- 將 memory / cpu 調整為：request `256Mi` / `100m`、limit `2Gi` / `1000m`
- 移除 `dev` 與 `main` overlay 中重複的 resources 覆蓋，讓兩個環境一致繼承 base

## 驗證
- `kubectl kustomize k8s/overlays/dev` 確認 render 後為 `256Mi / 2Gi / 100m / 1000m`
- `kubectl kustomize k8s/overlays/main` 確認 render 後為 `256Mi / 2Gi / 100m / 1000m`
- 獨立 reviewer 檢查 diff，未發現阻塞性問題

## 備註
- 這個 PR 的目的是把先前放在 overlay 的資源設定收回 base，讓 `main` / `dev` 行為一致
- 合併到 `dev` 後，`main` 會在後續從 `dev` 合回時一併帶到