### PR TITLE
ci: deploy 後固定 rollout restart

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -74,6 +74,11 @@ jobs:
           sed -i "s|newTag: .*|newTag: ${IMAGE_TAG}|g" "${KUSTOMIZE_DIR}/kustomization.yaml"
           kubectl apply -k "${KUSTOMIZE_DIR}"
 
+      - name: Rollout restart deployment
+        run: |
+          kubectl rollout restart "deployment/${RESOURCE_NAME}" \
+            -n "${{ env.K8S_NAMESPACE }}"
+
       - name: Verify deployment
         run: |
           kubectl rollout status "deployment/${RESOURCE_NAME}" \


### PR DESCRIPTION
## 摘要
- 在 deploy workflow 的 `kubectl apply -k` 之後固定執行 `kubectl rollout restart`
- 讓 GitHub 重新執行 deploy workflow 時，即使 manifest 或 image tag 沒變，也能重新觸發 deployment rollout

## 驗證
- 以 Python YAML parser 驗證 `.github/workflows/deploy.yml` 可正常解析
- 確認 deploy job 最後三個步驟為：`Deploy to Kubernetes` → `Rollout restart deployment` → `Verify deployment`

## 備註
- 這個 PR 是補上 workflow rerun 不會重新部署的問題
- 已先檢查 PR #8 狀態，確認它已合併，且這個 workflow 變更尚未進入 `dev`